### PR TITLE
Enable k-th root in quintic

### DIFF
--- a/example/pi_millions_with_boost_multiprecision.cpp
+++ b/example/pi_millions_with_boost_multiprecision.cpp
@@ -256,8 +256,8 @@ T quintic_borwein_for_pi()
    {
       T x_n = 5 / s_n - 1;
       T y_n = sqr(x_n - 1) + 7;
-      // T z_n = kth_root(x_n / 2 * (y_n + sqrt(sqr(y_n) - 4 * cube(x_n))), 5);
-      T z_n = pow(x_n / 2 * (y_n + sqrt(sqr(y_n) - 4 * cube(x_n))), inverse_five);
+      T z_n = kth_root(x_n / 2 * (y_n + sqrt(sqr(y_n) - 4 * cube(x_n))), 5);
+      // T z_n = pow(x_n / 2 * (y_n + sqrt(sqr(y_n) - 4 * cube(x_n))), inverse_five);
       s_n2 = sqr(s_n);
       a_n  = s_n2 * a_n - pow_five * ((s_n2 - 5) / 2 + sqrt(s_n * (s_n2 - 2 * s_n + 5)));
       s_n  = 25 / (sqr(z_n + x_n / z_n + 1) * s_n);
@@ -416,7 +416,7 @@ void run_time_experiments(size_t digits)
 
 int main()
 {
-   const unsigned int digits = 50000;
+   const unsigned int digits = 10000;
    
    pi::millions::detail::run_experiment<digits, pi::millions::detail::gauss_legendre_pi_unleashed>("Base pi");
    pi::millions::detail::run_experiment<digits, pi::millions::detail::cubic_borwein_pi_unleashed>("Base cubic");
@@ -430,4 +430,6 @@ int main()
    // pi::millions::detail::run_experiment<pi::millions::detail::chudnovsky_for_pi>("Chudnovsky pi");
    
    RUN_ALL_TIMED_EXPERIMENTS(float_type, pi::millions::detail::gauss_legendre_pi_unleashed);
+
+   return 0;
 }

--- a/example/pi_millions_with_boost_multiprecision/pi_millions_with_boost_multiprecision.vcxproj
+++ b/example/pi_millions_with_boost_multiprecision/pi_millions_with_boost_multiprecision.vcxproj
@@ -146,7 +146,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <AdditionalIncludeDirectories>C:\Users\Dimitris\Documents\Libraries\boost_1_73_0</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\Users\Dimitris\Documents\GitHub\boost</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Updated table:

|Method/N| GL Un | Cub Un | GL | Qd | Cub | Qr | Qn | Non |
|--| --    | --     | -- |  --|  -- |  --|  --|  -- |  
|1K|0.003268s|0.003646s|0.000948s|0.002509s|0.003997s|0.001952s|0.012384s|0.006122s|
||0.017836s|0.004957s|0.009617s|0.008635s|0.004179s|0.013524s|0.208164s|0.005892s
|5K|0.012640s|0.113406s|0.020494s|0.063762s|0.116883s|0.029694s|0.313708s|0.149207s|
||0.255039s|0.130431s|0.268763s|0.263724s|0.126375s|0.284409s|18.019207s|0.163338s
|10K|0.047336s|0.473562s|0.064468s|0.298860s|0.433946s|0.096938s|1.32719s| 0.548498s|
||1.094545s|0.517367s|1.091298s|0.969387s|0.485853s|1.050066s|155.949646s|0.686482s
|50K|1.075196s|10.947395s|1.115937s|5.745923s|11.148762s|2.091759s| 41.4093s|15.325591s
||27.866652s|13.622281s|28.721098s|26.763367s|12.883669s|35.426968s| |17.174911s
|100K|3.919699s| |4.652693s|26.834837s| |9.370837s|
||
500K|97.616852s| |121.964401s
||